### PR TITLE
Bugfix: use DeallocBlockExecutor to notify MTKObserver to detach when target is deallocing

### DIFF
--- a/Block Key-Value Observing.xcodeproj/project.pbxproj
+++ b/Block Key-Value Observing.xcodeproj/project.pbxproj
@@ -37,6 +37,12 @@
 		85388F0019AE3BEB00FD9225 /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B7A2BF816AFDE05009214C9 /* metamacros.h */; };
 		85388F0119AE3C0400FD9225 /* NSObject+MTKObserving.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B7A2BFD16AFDE05009214C9 /* NSObject+MTKObserving.m */; };
 		85388F0219AE3C0400FD9225 /* MTKObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B7A2BFA16AFDE05009214C9 /* MTKObserver.m */; };
+		EC4451CA1BF9DA3700BB5475 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC4451C91BF9DA3700BB5475 /* UIKit.framework */; };
+		EC4451DB1BFC36D500BB5475 /* MTKDeallocBlockExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = EC4451D91BFC36D500BB5475 /* MTKDeallocBlockExecutor.h */; };
+		EC4451DC1BFC36D600BB5475 /* MTKDeallocBlockExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = EC4451DA1BFC36D500BB5475 /* MTKDeallocBlockExecutor.m */; };
+		EC4451E01BFC370200BB5475 /* MTKDeallocBlockExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = EC4451DA1BFC36D500BB5475 /* MTKDeallocBlockExecutor.m */; };
+		EC4451E31BFC78B600BB5475 /* NSObject+MTKDeallocBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = EC4451E11BFC78B600BB5475 /* NSObject+MTKDeallocBlock.h */; };
+		EC4451E41BFC78B600BB5475 /* NSObject+MTKDeallocBlock.m in Sources */ = {isa = PBXBuildFile; fileRef = EC4451E21BFC78B600BB5475 /* NSObject+MTKDeallocBlock.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -89,6 +95,11 @@
 		5BC45C6019B8646100AFE784 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		5BC45C6219B8646100AFE784 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		5BCB3DD919B84DCB00C33E9D /* XCTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XCTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC4451C91BF9DA3700BB5475 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		EC4451D91BFC36D500BB5475 /* MTKDeallocBlockExecutor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTKDeallocBlockExecutor.h; sourceTree = "<group>"; };
+		EC4451DA1BFC36D500BB5475 /* MTKDeallocBlockExecutor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTKDeallocBlockExecutor.m; sourceTree = "<group>"; };
+		EC4451E11BFC78B600BB5475 /* NSObject+MTKDeallocBlock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+MTKDeallocBlock.h"; sourceTree = "<group>"; };
+		EC4451E21BFC78B600BB5475 /* NSObject+MTKDeallocBlock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+MTKDeallocBlock.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +107,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EC4451CA1BF9DA3700BB5475 /* UIKit.framework in Frameworks */,
 				5B18EADD16B2F5AA00362576 /* libBlockObserving.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -167,7 +179,11 @@
 				5B7A2BFD16AFDE05009214C9 /* NSObject+MTKObserving.m */,
 				5B7A2BF916AFDE05009214C9 /* MTKObserver.h */,
 				5B7A2BFA16AFDE05009214C9 /* MTKObserver.m */,
+				EC4451D91BFC36D500BB5475 /* MTKDeallocBlockExecutor.h */,
+				EC4451DA1BFC36D500BB5475 /* MTKDeallocBlockExecutor.m */,
 				5B7A2BF616AFDE05009214C9 /* Utilities */,
+				EC4451E11BFC78B600BB5475 /* NSObject+MTKDeallocBlock.h */,
+				EC4451E21BFC78B600BB5475 /* NSObject+MTKDeallocBlock.m */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -223,6 +239,7 @@
 		5BC45C5D19B8646100AFE784 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				EC4451C91BF9DA3700BB5475 /* UIKit.framework */,
 				5BC45C5E19B8646100AFE784 /* XCTest.framework */,
 				5BC45C6019B8646100AFE784 /* Foundation.framework */,
 				5BC45C6219B8646100AFE784 /* UIKit.framework */,
@@ -238,8 +255,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				5B7A2BFE16AFDE05009214C9 /* keypath.h in Headers */,
+				EC4451DB1BFC36D500BB5475 /* MTKDeallocBlockExecutor.h in Headers */,
 				5B7A2BFF16AFDE05009214C9 /* metamacros.h in Headers */,
 				5B7A2C0016AFDE05009214C9 /* MTKObserver.h in Headers */,
+				EC4451E31BFC78B600BB5475 /* NSObject+MTKDeallocBlock.h in Headers */,
 				5B7A2C0216AFDE05009214C9 /* MTKObserving.h in Headers */,
 				5B7A2C0316AFDE05009214C9 /* NSObject+MTKObserving.h in Headers */,
 				5B8AF2EF16C285A5002135D2 /* scope.h in Headers */,
@@ -413,7 +432,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				5B7A2C0116AFDE05009214C9 /* MTKObserver.m in Sources */,
+				EC4451DC1BFC36D600BB5475 /* MTKDeallocBlockExecutor.m in Sources */,
 				5B7A2C0416AFDE05009214C9 /* NSObject+MTKObserving.m in Sources */,
+				EC4451E41BFC78B600BB5475 /* NSObject+MTKDeallocBlock.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -431,6 +452,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				85388F0119AE3C0400FD9225 /* NSObject+MTKObserving.m in Sources */,
+				EC4451E01BFC370200BB5475 /* MTKDeallocBlockExecutor.m in Sources */,
 				85388F0219AE3C0400FD9225 /* MTKObserver.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Example.m
+++ b/Example/Example.m
@@ -10,4 +10,8 @@
 
 @implementation Example
 
+- (void)dealloc
+{
+    NSLog(@"Example dealloc!");
+}
 @end

--- a/Example/Main.m
+++ b/Example/Main.m
@@ -32,6 +32,10 @@ int main(int argc, char *argv[]) {
 	/// It is safe to call it multiple times or even ahen no observations are created.
 	[self removeAllObservations];
 	
+    [self.property observeProperty:@"title" withBlock:^(id example, id old, id new) {}];
+    self.property = nil;
+    NSLog(@"release self.property");
+    
 	return YES;
 }
 

--- a/Sources/MTKDeallocBlockExecutor.h
+++ b/Sources/MTKDeallocBlockExecutor.h
@@ -1,0 +1,15 @@
+//
+//  MTKDeallocBlockExecutor.h
+//  Block Key-Value Observing
+//
+//  Created by Yanjun Zhuang on 18/11/15.
+//  Copyright © 2015 iMartin Kiss. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface MTKDeallocBlockExecutor : NSObject
+@property (nonatomic, copy) void (^deallocBlock)();
+
++ (instancetype)executorWithDellocBlock:(void (^)())deallocBlock;
+@end

--- a/Sources/MTKDeallocBlockExecutor.m
+++ b/Sources/MTKDeallocBlockExecutor.m
@@ -1,0 +1,26 @@
+//
+//  MTKDeallocExecutor.m
+//  Block Key-Value Observing
+//
+//  Created by Yanjun Zhuang on 18/11/15.
+//  Copyright © 2015 iMartin Kiss. All rights reserved.
+//
+
+#import "MTKDeallocBlockExecutor.h"
+
+@implementation MTKDeallocBlockExecutor
++ (instancetype)executorWithDellocBlock:(void (^)())deallocBlock
+{
+    MTKDeallocBlockExecutor *executor = [[self alloc] init];
+    executor.deallocBlock = deallocBlock;
+    return executor;
+}
+
+- (void)dealloc
+{
+    if (self.deallocBlock) {
+        self.deallocBlock();
+        self.deallocBlock = nil;
+    }
+}
+@end

--- a/Sources/MTKObserver.h
+++ b/Sources/MTKObserver.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-
+NSString *const kMTKObservingDeallocingNotification;
 
 #pragma mark Block Typedefs
 

--- a/Sources/MTKObserver.h
+++ b/Sources/MTKObserver.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-NSString *const kMTKObservingDeallocingNotification;
+extern NSString *const kMTKObservingDeallocingNotification;
 
 #pragma mark Block Typedefs
 

--- a/Sources/MTKObserver.m
+++ b/Sources/MTKObserver.m
@@ -8,7 +8,7 @@
 
 #import "MTKObserver.h"
 
-
+NSString *const kMTKObservingDeallocingNotification = @"kMTKObservingDeallocingNotification"; // Notification to notify target is deallocing
 
 #pragma mark Private Interface
 
@@ -60,13 +60,16 @@
 }
 
 - (void)dealloc {
-    // RemoveObserver if it is still attached
-    if (self.attached) {
-        [self.target removeObserver:self forKeyPath:self.keyPath];
-    }
-	//NSLog(@"Observer dealloc %@ %@", self.target, self.keyPath);
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+	//NSLog(@"Observer dealloc %@", self.keyPath);
 }
 
+#pragma mark Target Deallocing Notification
+- (void)onTargetDeallocing
+{
+    //NSLog(@"Target deallocing..");
+    [self detach];
+}
 
 
 #pragma Adding Blocks
@@ -112,9 +115,13 @@
              NSKeyValueObservingOptionOld |
              NSKeyValueObservingOptionNew
                              context:nil];
+            
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onTargetDeallocing) name:kMTKObservingDeallocingNotification object:self.target];
         }
         else {
             [self.target removeObserver:self forKeyPath:self.keyPath];
+            
+            [[NSNotificationCenter defaultCenter] removeObserver:self];
         }
     }
 }

--- a/Sources/NSObject+MTKDeallocBlock.h
+++ b/Sources/NSObject+MTKDeallocBlock.h
@@ -1,0 +1,13 @@
+//
+//  NSObject+MTKDeallocBlock.h
+//  Block Key-Value Observing
+//
+//  Created by Yanjun Zhuang on 18/11/15.
+//  Copyright © 2015 iMartin Kiss. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSObject (MTKDeallocBlock)
+- (id)mtk_addDeallocBlock:(void (^)())deallocBlock;
+@end

--- a/Sources/NSObject+MTKDeallocBlock.m
+++ b/Sources/NSObject+MTKDeallocBlock.m
@@ -1,0 +1,37 @@
+//
+//  NSObject+MTKDeallocBlock.m
+//  Block Key-Value Observing
+//
+//  Created by Yanjun Zhuang on 18/11/15.
+//  Copyright © 2015 iMartin Kiss. All rights reserved.
+//
+
+#import "NSObject+MTKDeallocBlock.h"
+#import <objc/runtime.h>
+#import "MTKDeallocBlockExecutor.h"
+
+@implementation NSObject (MTKDeallocBlock)
+- (id)mtk_addDeallocBlock:(void (^)())deallocBlock
+{
+    static char associationKey;
+    if (deallocBlock == nil) {
+        return nil;
+    }
+    
+    NSMutableArray *deallocBlocks = objc_getAssociatedObject(self, &associationKey);
+    if (deallocBlocks == nil) {
+        deallocBlocks = [NSMutableArray array];
+        objc_setAssociatedObject(self, &associationKey, deallocBlocks, OBJC_ASSOCIATION_RETAIN);
+    }
+    // Check if the block is already existed
+    for (MTKDeallocBlockExecutor *executor in deallocBlocks) {
+        if (executor.deallocBlock == deallocBlock) {
+            return nil;
+        }
+    }
+    
+    MTKDeallocBlockExecutor *executor = [MTKDeallocBlockExecutor executorWithDellocBlock:deallocBlock];
+    [deallocBlocks addObject:executor];
+    return executor;
+}
+@end


### PR DESCRIPTION
since MTKObserver is element of a array which is a association object of target, MTKObserver's `dealloc` will delay to call until next runloop after target is dealloced. So I use deallocBlockExecutor as a helper to notify the related MTKObservers to detach ASAP.